### PR TITLE
Actually require module-alias

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+require('module-alias/register');
 import * as vm from "./modules/vm";
 import { Room } from "./classes/room";
 import { load, save } from "./modules/load";


### PR DESCRIPTION
MOOts defines and uses module-alias, but then does not actually
require the module, so the translation wasn't being made.